### PR TITLE
Code generation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,4 +3,5 @@ blockquote {
   border-left: 0.5em solid #aaa;
   padding: 0.25em;
   box-shadow: 0px 0px 3px #5555;
+  margin-bottom: 0;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,6 @@
-.App {
-  text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+blockquote {
+  background-color: #eee;
+  border-left: 0.5em solid #aaa;
+  padding: 0.25em;
+  box-shadow: 0px 0px 3px #5555;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ const App = () => {
           ></Input>
         </Panel>
         <Panel>
-          <p id="md-output">{mdOutput}</p>
+          <p id="md-output" dangerouslySetInnerHTML={{ __html: mdOutput }}></p>
         </Panel>
       </Row>
     </Container>

--- a/src/compiler/codeGenerator/index.ts
+++ b/src/compiler/codeGenerator/index.ts
@@ -1,0 +1,27 @@
+import { TreeTraverser, TreeNode, ASTNode, ASTRoot, ASTBranch } from "../nodes";
+import { astTable } from "../symbolTable";
+
+export class CodeGenerator {
+  readonly html: string;
+  constructor(readonly root: ASTRoot) {
+    const codeGeneratorTraverser = new CodeGeneratorTraverser();
+    root.Accept(codeGeneratorTraverser);
+    this.html = codeGeneratorTraverser.html;
+  }
+}
+
+class CodeGeneratorTraverser extends TreeTraverser {
+  private _html: string = "";
+  get html() {
+    return this._html;
+  }
+
+  VisitNode(node: TreeNode) {
+    const htmlTag = astTable[(node as ASTNode).nodeType].htmlTagContent;
+
+    if (htmlTag) this._html += `<${htmlTag}>`;
+    else if (node instanceof ASTBranch) this._html += node.content;
+    super.VisitNode(node);
+    if (htmlTag) this._html += `</${htmlTag}>`;
+  }
+}

--- a/src/compiler/codeGenerator/index.ts
+++ b/src/compiler/codeGenerator/index.ts
@@ -1,5 +1,6 @@
 import { TreeTraverser, TreeNode, ASTNode, ASTRoot, ASTBranch } from "../nodes";
 import { astTable } from "../symbolTable";
+import { ASTNodeType } from "../symbolTable/types";
 
 export class CodeGenerator {
   readonly html: string;
@@ -17,11 +18,26 @@ class CodeGeneratorTraverser extends TreeTraverser {
   }
 
   VisitNode(node: TreeNode) {
-    const htmlTag = astTable[(node as ASTNode).nodeType].htmlTagContent;
+    const nodeType = (node as ASTNode).nodeType;
+    const [openTag, closeTag] = this.GetOpenCloseTags(nodeType);
 
-    if (htmlTag) this._html += `<${htmlTag}>`;
-    else if (node instanceof ASTBranch) this._html += node.content;
+    // if (htmlTag) this._html += `<${htmlTag}>`;
+    // else if (node instanceof ASTBranch) this._html += node.content;
+    this._html += openTag;
+    if (openTag === "" && node instanceof ASTBranch) this._html += node.content;
     super.VisitNode(node);
-    if (htmlTag) this._html += `</${htmlTag}>`;
+    this._html += closeTag;
+    // if (htmlTag) this._html += `</${htmlTag}>`;
+  }
+
+  private GetOpenCloseTags(nodeType: ASTNodeType): [string, string] {
+    const astEle = astTable[nodeType];
+
+    if (astEle.htmlTagContent) {
+      if (astEle.tagIsSelfClosing) return [`<${astEle.htmlTagContent}/>`, ""];
+      else return [`<${astEle.htmlTagContent}>`, `</${astEle.htmlTagContent}>`];
+    }
+
+    return ["", ""];
   }
 }

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -1,7 +1,7 @@
 import { Tokenizer, Token } from "./tokenizer";
 import { SyntacticAnalyser } from "./syntacticAnalyser";
 import { Transformer } from "./transformer";
-import { TreeLogger } from "./nodes";
+import { CodeGenerator } from "./codeGenerator";
 
 export class Compiler {
   readonly compiled: string = "";
@@ -10,12 +10,12 @@ export class Compiler {
     const tokenizer = new Tokenizer(input.split(/\r?\n/));
     const tokens: Token[] = tokenizer.tokens;
 
-    for (const token of tokens) {
-      this.compiled += `{${token.type}, ${token.value}}, `;
-    }
-
     const syntacticAnalyser = new SyntacticAnalyser(tokens);
 
     const transformer = new Transformer(syntacticAnalyser.rootNode);
+
+    const codeGenerator = new CodeGenerator(transformer.astRoot);
+    console.log(codeGenerator.html);
+    this.compiled = codeGenerator.html;
   }
 }

--- a/src/compiler/nodes/nodes.ts
+++ b/src/compiler/nodes/nodes.ts
@@ -53,7 +53,11 @@ export class BranchNode extends TreeNode {
 }
 
 export class ASTNode extends TreeNode {
-  constructor(nodeID: number, readonly nodeType: ASTNodeType) {
+  constructor(
+    nodeID: number,
+    readonly nodeType: ASTNodeType,
+    public count: number = 1
+  ) {
     super(nodeID);
   }
 }
@@ -67,10 +71,11 @@ export class ASTRoot extends ASTNode {
 export class ASTBranch extends ASTNode {
   constructor(
     nodeID: number,
-    readonly parent: TreeNode,
+    readonly parent: ASTNode,
     nodeType: ASTNodeType,
-    readonly content: string
+    readonly content: string,
+    count: number = 1
   ) {
-    super(nodeID, nodeType);
+    super(nodeID, nodeType, count);
   }
 }

--- a/src/compiler/nodes/nodes.ts
+++ b/src/compiler/nodes/nodes.ts
@@ -4,6 +4,12 @@ import { Token } from "../tokenizer";
 
 export abstract class TreeNode implements IVisitable {
   private children?: this[];
+  public get childCount() {
+    return this.children?.length ?? 0;
+  }
+  public get lastChild() {
+    return this.children ? this.children[this.childCount - 1] : undefined;
+  }
   constructor(readonly nodeID: number) {}
 
   AddChild(node: this) {
@@ -15,6 +21,10 @@ export abstract class TreeNode implements IVisitable {
 
   GetChildren() {
     return (this.children ?? []) as readonly this[];
+  }
+
+  GetChild(index: number) {
+    return this.GetChildren()[index];
   }
 
   HasChildren() {

--- a/src/compiler/symbolTable/index.ts
+++ b/src/compiler/symbolTable/index.ts
@@ -80,9 +80,11 @@ export const astTable: Record<ASTNodeType, ASTElement> = {
   },
   newline: {
     htmlTagContent: "br",
+    tagIsSelfClosing: true,
   },
   hr: {
     htmlTagContent: "hr",
+    tagIsSelfClosing: true,
   },
   markdown: {
     htmlTagContent: "div",

--- a/src/compiler/symbolTable/index.ts
+++ b/src/compiler/symbolTable/index.ts
@@ -70,7 +70,7 @@ export const astTable: Record<ASTNodeType, ASTElement> = {
     htmlTagContent: "ol",
   },
   ulistelement: {
-    htmlTagContent: "ul",
+    htmlTagContent: "li",
   },
   code: {
     htmlTagContent: "code",

--- a/src/compiler/symbolTable/index.ts
+++ b/src/compiler/symbolTable/index.ts
@@ -55,39 +55,37 @@ export const symbolTable: Record<SymbolType, SymbolElement> = {
 
 export const astTable: Record<ASTNodeType, ASTElement> = {
   heading: {
-    htmlTagContent: "h",
+    htmlTagGenerator: (node) => `h${node.count}`,
   },
-  bold: {
-    htmlTagContent: "b",
-  },
-  italic: {
-    htmlTagContent: "i",
+  boldit: {
+    htmlTagGenerator: (node) =>
+      node.count >= 3 ? ["b", "i"] : node.count === 2 ? "b" : "i",
   },
   blockquote: {
-    htmlTagContent: "blockquote",
+    htmlTagGenerator: (_node) => "blockquote",
   },
   olistelement: {
-    htmlTagContent: "ol",
+    htmlTagGenerator: (_node) => "ol",
   },
   ulistelement: {
-    htmlTagContent: "li",
+    htmlTagGenerator: (_node) => "li",
   },
   code: {
-    htmlTagContent: "code",
+    htmlTagGenerator: (_node) => "code",
   },
   text: {
-    htmlTagContent: "",
+    htmlTagGenerator: (_node) => "",
   },
   newline: {
-    htmlTagContent: "br",
+    htmlTagGenerator: (_node) => "br",
     tagIsSelfClosing: true,
   },
   hr: {
-    htmlTagContent: "hr",
+    htmlTagGenerator: (node) => `hr${node.count}`,
     tagIsSelfClosing: true,
   },
   markdown: {
-    htmlTagContent: "div",
+    htmlTagGenerator: (_node) => "div",
   },
 };
 

--- a/src/compiler/symbolTable/types.ts
+++ b/src/compiler/symbolTable/types.ts
@@ -1,3 +1,5 @@
+import { ASTNode } from "../nodes";
+
 export type SymbolType = "#" | "*" | ">" | "-" | "`" | "\\" | "  " | "\\n";
 export type SymbolTypeOrText = SymbolType | "text";
 
@@ -11,8 +13,7 @@ export type SymbolElement = {
 
 export type ASTNodeType =
   | "heading"
-  | "bold"
-  | "italic"
+  | "boldit"
   | "blockquote"
   | "olistelement"
   | "ulistelement"
@@ -25,6 +26,7 @@ export type ASTNodeType =
   | "markdown";
 
 export type ASTElement = {
-  htmlTagContent: string;
+  // htmlTagContent: string;
+  htmlTagGenerator: (node: ASTNode) => string | string[];
   tagIsSelfClosing?: boolean;
 };

--- a/src/compiler/symbolTable/types.ts
+++ b/src/compiler/symbolTable/types.ts
@@ -26,4 +26,5 @@ export type ASTNodeType =
 
 export type ASTElement = {
   htmlTagContent: string;
+  tagIsSelfClosing?: boolean;
 };

--- a/src/compiler/transformer/index.ts
+++ b/src/compiler/transformer/index.ts
@@ -14,9 +14,11 @@ import { ASTNodeType } from "../symbolTable/types";
 import { Token } from "../tokenizer";
 
 export class Transformer {
+  readonly astRoot: ASTRoot;
   constructor(readonly root: RootNode) {
     const astTransformer = new ASTTransformer();
     root.Accept(astTransformer);
+    this.astRoot = astTransformer.root;
 
     const treeLogger = new TreeLogger<ASTBranch>(
       (node) => `{${node.nodeID}, ${node.nodeType}, ${node.content}}`
@@ -27,7 +29,7 @@ export class Transformer {
 
 class ASTTransformer extends TreeTraverser {
   private readonly nodeAssembler = new ASTNodeAssembler();
-  get root(): RootNode {
+  get root(): ASTRoot {
     return this.nodeAssembler.root;
   }
 
@@ -55,7 +57,7 @@ class ASTNodeAssembler {
       switch (node.token.symbol.symbolType) {
         case "#":
         case "-":
-          debugger;
+        case ">":
           astType = "text";
           enterNode = false;
           break;


### PR DESCRIPTION
Makes the following changes:
- Adds HTML code generation
- Adds utility functions to tree nodes
- Removes default create-react-app css
- Changes `ASTTable` to use functions for generating tags instead of strings (allows for generating different tags based on node properties)
- Fixes #7 